### PR TITLE
Improve readability by making the landingpage's content smaller in width

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -25,3 +25,6 @@ indent_size = 4
 
 [Makefile]
 indent_style = tab
+
+[*.md]
+trim_trailing_whitespace = false

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -3,7 +3,7 @@
 
 <div class="container content">
 	<div class="row">
-		<div class="col-xs-12">
+		<div class="col-lg-8 offset-lg-2">
 			{{ range where .Site.Pages "Type" "page" }}
 				{{ .Content }}
 			{{ end }}


### PR DESCRIPTION
Now 8/12 and centered on bigger (lg) devices.