### PR TITLE
Replace Discord chat link with a matrix.to link

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -50,8 +50,8 @@ menu:
       url: https://github.com/go-gitea/
       weight: 60
       pre: github
-    - name: Discord Chat
-      url: https://discord.gg/NsatcWJ
+    - name: Chat
+      url: https://matrix.to/#/#gitea:matrix.org
       weight: 70
       pre: comment
     - name: Forum


### PR DESCRIPTION
Friends don't send friends to proprietary software based
services...